### PR TITLE
Pin Gorm to Master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,15 +67,15 @@
   version = "v1.5.7"
 
 [[projects]]
-  digest = "1:6895fbe5a10c5aebd1965cac6f6905dcdb21bee01e08912d3ba6a805c2485f6a"
+  branch = "master"
+  digest = "1:7b4c43b17175f212ca55e83034f9f2ea7c34602819e8a6db994d37d2b9218659"
   name = "github.com/jinzhu/gorm"
   packages = [
     ".",
     "dialects/postgres",
   ]
   pruneopts = "UT"
-  revision = "6ed508ec6a4ecb3531899a69cbc746ccf65a4166"
-  version = "v1.9.1"
+  revision = "5ad6f621e6f59672f5b5061df85b243436fde048"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/jinzhu/gorm"
-  version = "1.9.1"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/lib/pq"


### PR DESCRIPTION
There was a data race issue in the version we were using (1.9.1). Gorm doesn't really do much versioning, usually several months apart. The last release `1.9.2` was in november, and doesn't include the fix for the data race, so we are forced to pin to master.

It might be a good idea to fork the gorm codebase, so we can do our own versioning.