### PR TITLE
Change GORM to RTrade Fork

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,17 @@
   revision = "858050bd60710361598cd4da2d8b316677fe6374"
 
 [[projects]]
+  branch = "versioned"
+  digest = "1:cbfe83c6fd0098e4bb003e968c7ec3d5526505287698a972b11c0caa4abe4935"
+  name = "github.com/RTradeLtd/gorm"
+  packages = [
+    ".",
+    "dialects/postgres",
+  ]
+  pruneopts = "UT"
+  revision = "d2072fe8bb4a46e42fe4f8097f8c015cac19b08c"
+
+[[projects]]
   branch = "master"
   digest = "1:4cf11742b199ab3aacf26b00187e72f7ff8ba2145f363b74f295d54f098f79e4"
   name = "github.com/agl/ed25519"
@@ -65,17 +76,6 @@
   pruneopts = "UT"
   revision = "14e95105cbafcda64fdc36197fe6a30b23c693dc"
   version = "v1.5.7"
-
-[[projects]]
-  branch = "master"
-  digest = "1:7b4c43b17175f212ca55e83034f9f2ea7c34602819e8a6db994d37d2b9218659"
-  name = "github.com/jinzhu/gorm"
-  packages = [
-    ".",
-    "dialects/postgres",
-  ]
-  pruneopts = "UT"
-  revision = "5ad6f621e6f59672f5b5061df85b243436fde048"
 
 [[projects]]
   branch = "master"
@@ -237,9 +237,9 @@
   analyzer-version = 1
   input-imports = [
     "github.com/RTradeLtd/config",
+    "github.com/RTradeLtd/gorm",
+    "github.com/RTradeLtd/gorm/dialects/postgres",
     "github.com/ipfs/go-ipfs-addr",
-    "github.com/jinzhu/gorm",
-    "github.com/jinzhu/gorm/dialects/postgres",
     "github.com/lib/pq",
     "github.com/multiformats/go-multiaddr",
     "golang.org/x/crypto/bcrypt",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,8 +7,8 @@
   version = "0.1.25"
 
 [[constraint]]
-  name = "github.com/jinzhu/gorm"
-  branch = "master"
+  name = "github.com/RTradeLtd/gorm"
+  branch = "versioned"
 
 [[constraint]]
   name = "github.com/lib/pq"

--- a/database.go
+++ b/database.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/RTradeLtd/config"
 	"github.com/RTradeLtd/database/models"
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 
 	// import our postgres dialect used to talk with a postgres databse
-	_ "github.com/jinzhu/gorm/dialects/postgres"
+	_ "github.com/RTradeLtd/gorm/dialects/postgres"
 )
 
 var (

--- a/database_test.go
+++ b/database_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/RTradeLtd/config"
 	"github.com/RTradeLtd/database"
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 )
 
 var (

--- a/models/encrypted.go
+++ b/models/encrypted.go
@@ -3,7 +3,7 @@ package models
 import (
 	"strings"
 
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 )
 
 // EncryptedUpload is an uploaded that has been encrypted by Temporal

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/RTradeLtd/database/utils"
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 	"github.com/lib/pq"
 )
 

--- a/models/ipns.go
+++ b/models/ipns.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 	"github.com/lib/pq"
 )
 

--- a/models/ipns_test.go
+++ b/models/ipns_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/RTradeLtd/config"
 	"github.com/RTradeLtd/database/models"
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 )
 
 const (

--- a/models/payment.go
+++ b/models/payment.go
@@ -3,7 +3,7 @@ package models
 import (
 	"errors"
 
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 )
 
 // Payments is our payment model

--- a/models/record.go
+++ b/models/record.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 )
 
 // Record is an entry within a tns zone

--- a/models/tns.go
+++ b/models/tns.go
@@ -3,7 +3,7 @@ package models
 import (
 	"errors"
 
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 	"github.com/lib/pq"
 )
 

--- a/models/upload.go
+++ b/models/upload.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/RTradeLtd/database/utils"
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 	"github.com/lib/pq"
 )
 

--- a/models/user.go
+++ b/models/user.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/RTradeLtd/database/utils"
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 	"github.com/lib/pq"
 	"golang.org/x/crypto/bcrypt"
 )


### PR DESCRIPTION
0 versioning in non-forked repo is causing head aches and already broke some stuff. This locks our gorm dependency to the rtrade maintained fork