### PR TITLE
models: add access control fields to private networks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,6 +41,14 @@
   revision = "67e573d211ace594f1366b4ce9d39726c4b19bd0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:e8891cd354f2af940345f895d5698ab1ed439196d4f69eb44817fc91e80354c1"
+  name = "github.com/c2h5oh/datasize"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4eba002a5eaea69cf8d235a388fc6b65ae68d2dd"
+
+[[projects]]
   digest = "1:bbadccf3d3317ea03c0dac0b45b673b4b397c8f91a1d2eff550a3c51c4ad770e"
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
@@ -76,6 +84,14 @@
   pruneopts = "UT"
   revision = "14e95105cbafcda64fdc36197fe6a30b23c693dc"
   version = "v1.5.7"
+
+[[projects]]
+  digest = "1:d4e6e8584d0a94ce567d237e19192dae44d57d2767ac7e1d7fbf5626d176381a"
+  name = "github.com/jinzhu/gorm"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "472c70caa40267cb89fd8facb07fe6454b578626"
+  version = "v1.9.2"
 
 [[projects]]
   branch = "master"
@@ -239,7 +255,9 @@
     "github.com/RTradeLtd/config",
     "github.com/RTradeLtd/gorm",
     "github.com/RTradeLtd/gorm/dialects/postgres",
+    "github.com/c2h5oh/datasize",
     "github.com/ipfs/go-ipfs-addr",
+    "github.com/jinzhu/gorm",
     "github.com/lib/pq",
     "github.com/multiformats/go-multiaddr",
     "golang.org/x/crypto/bcrypt",

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -16,23 +16,31 @@ type HostedIPFSPrivateNetwork struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
-	Name      string `gorm:"unique;type:varchar(255)"`
-	Activated time.Time
+	Name      string    `gorm:"unique;type:varchar(255)"` // Name of the network node
+	Activated time.Time // Activated represents the most recent activation, 0-value if offline
 
+	// SwarmAddr is the address of swarm port. Slated for deprecation if HTTP path
+	// support is added to the multiaddr spec and go-multiaddr
 	SwarmAddr string `gorm:"type:varchar(255)"`
-	SwarmKey  string `gorm:"type:varchar(255)"`
+	// SwarmKey is the key used to connect to this peer
+	SwarmKey string `gorm:"type:varchar(255)"`
 
+	// Used to set Allowed-Origin headers on API requests
 	APIAllowedOrigin string `gorm:"type:varchar(255)"`
 
+	// Toggles whether gateway should be exposed through Nexus delegator
 	GatewayPublic bool `gorm:"type:boolean"`
 
+	// Peers to bootstrap node onto
 	BootstrapPeerAddresses pq.StringArray `gorm:"type:text[]"`
 	BootstrapPeerIDs       pq.StringArray `gorm:"type:text[];column:bootstrap_peer_ids"`
 
+	// Resources for deployed node
 	ResourcesCPUs     int
 	ResourcesDiskGB   int
 	ResourcesMemoryGB int
 
+	// Users allowed to control this node. Includes API access.
 	Users pq.StringArray `gorm:"type:text[]"` // these are the users to which this IPFS network connection applies to specified by eth address
 }
 

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -19,6 +19,8 @@ type HostedIPFSPrivateNetwork struct {
 	Name      string    `gorm:"unique;type:varchar(255)"` // Name of the network node
 	Activated time.Time // Activated represents the most recent activation, 0-value if offline
 
+	PeerID string // PeerID of this network node
+
 	// SwarmAddr is the address of swarm port. Slated for deprecation if HTTP path
 	// support is added to the multiaddr spec and go-multiaddr
 	SwarmAddr string `gorm:"type:varchar(255)"`

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -19,7 +19,7 @@ type HostedIPFSPrivateNetwork struct {
 	Name      string    `gorm:"unique;type:varchar(255)"` // Name of the network node
 	Activated time.Time // Activated represents the most recent activation, 0-value if offline
 
-	PeerID string // PeerID of this network node
+	PeerKey string // Private key used to generate peerID for this network node
 
 	// SwarmAddr is the address of swarm port. Slated for deprecation if HTTP path
 	// support is added to the multiaddr spec and go-multiaddr

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -22,7 +22,7 @@ type HostedIPFSPrivateNetwork struct {
 	SwarmAddr string `gorm:"type:varchar(255)"`
 	SwarmKey  string `gorm:"type:varchar(255)"`
 
-	APIOrigins []string `gorm:"type:text[]"`
+	APIAllowedOrigin string `gorm:"type:varchar(255)"`
 
 	GatewayPublic bool `gorm:"type:boolean"`
 
@@ -75,7 +75,7 @@ func (im *IPFSNetworkManager) GetSwarmDetails(network string) (*SwarmDetails, er
 
 // APIDetails provides data about IPFS API connection
 type APIDetails struct {
-	AllowedOrigins []string
+	AllowedOrigin string
 }
 
 // GetAPIDetails is used to retrieve data about IPFS API connection
@@ -85,7 +85,7 @@ func (im *IPFSNetworkManager) GetAPIDetails(network string) (*APIDetails, error)
 		return nil, err
 	}
 	return &APIDetails{
-		AllowedOrigins: pnet.APIOrigins,
+		AllowedOrigin: pnet.APIAllowedOrigin,
 	}, nil
 }
 
@@ -108,9 +108,9 @@ func (im *IPFSNetworkManager) SaveNetwork(n *HostedIPFSPrivateNetwork) error {
 
 // NetworkAccessOptions configures access to a hosted private network
 type NetworkAccessOptions struct {
-	Users             []string
-	APIAllowedOrigins []string
-	PublicGateway     bool
+	Users            []string
+	APIAllowedOrigin string
+	PublicGateway    bool
 }
 
 // CreateHostedPrivateNetwork is used to store a new hosted private network in the database
@@ -169,7 +169,7 @@ func (im *IPFSNetworkManager) CreateHostedPrivateNetwork(name, swarmKey string, 
 	// assign misc details
 	pnet.Name = name
 	pnet.SwarmKey = swarmKey
-	pnet.APIOrigins = access.APIAllowedOrigins
+	pnet.APIAllowedOrigin = access.APIAllowedOrigin
 	pnet.GatewayPublic = access.PublicGateway
 
 	// create network entry

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -98,6 +98,14 @@ func (im *IPFSNetworkManager) UpdateNetworkByName(name string, attrs map[string]
 	return nil
 }
 
+// SaveNetwork saves the given HostedIPFSPrivateNetwork in the database
+func (im *IPFSNetworkManager) SaveNetwork(n *HostedIPFSPrivateNetwork) error {
+	if check := im.DB.Save(n); check != nil && check.Error != nil {
+		return check.Error
+	}
+	return nil
+}
+
 // NetworkAccessOptions configures access to a hosted private network
 type NetworkAccessOptions struct {
 	Users             []string

--- a/models/usage.go
+++ b/models/usage.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/c2h5oh/datasize"
 
-	"github.com/jinzhu/gorm"
+	"github.com/RTradeLtd/gorm"
 )
 
 // DataUsageTier is a type of usage tier


### PR DESCRIPTION
Explanations:
- `APIUrl` removal: direct API access is dangerous, work on https://github.com/RTradeLtd/ipfs-orchestrator/pull/13 will continue to allow compatibility with Temporal JWT tokens to implement access control
- `APIOrigins`: allowed origins for accessing the API (preferably not `*`)
- `SwarmAddr`: the new delegator uses HTTP paths. Since multiaddr doesn't work with paths, we don't have much of a choice other than expose it directly on a port, so that will need to be in the database. On a side note, this really puts a stopper on plans for a distributed orchestrator 😢 
- `GatewayPublic`: we currently dont expose the gateway for each node, but we *could*. though obviously we want this to be configurable, since not everyone wants to expose everything