### PR TITLE
database: refactor and cleanup (breaking change)

### DIFF
--- a/database.go
+++ b/database.go
@@ -12,27 +12,6 @@ import (
 	_ "github.com/RTradeLtd/gorm/dialects/postgres"
 )
 
-var (
-	// UploadObj is our upload model
-	UploadObj *models.Upload
-	// EncryptedUploadObj is our encrypted upload model
-	EncryptedUploadObj *models.EncryptedUpload
-	// UserObj is our user model
-	UserObj *models.User
-	// PaymentObj is our payment model
-	PaymentObj *models.Payments
-	// IpnsObj is our ipns model
-	IpnsObj *models.IPNS
-	// HostedIpfsNetObj is our hosted ipfs network model
-	HostedIpfsNetObj *models.HostedIPFSPrivateNetwork
-	// TnsZoneObj is our tns zone model
-	TnsZoneObj *models.Zone
-	// TnsRecordObj is our tns record model
-	TnsRecordObj *models.Record
-	// UsagesRecordObj is our usage record model
-	UsagesRecordObj *models.Usage
-)
-
 // Manager is used to manage databases
 type Manager struct {
 	DB     *gorm.DB
@@ -44,15 +23,16 @@ type Options struct {
 	RunMigrations  bool
 	SSLModeDisable bool
 	LogMode        bool
+	Logger         Logger
 }
 
-// Initialize is used to init our connection to a database, and return a manager struct
-func Initialize(cfg *config.TemporalConfig, opts Options) (*Manager, error) {
+// New is used to init our connection to a database, and return a manager struct
+func New(cfg *config.TemporalConfig, opts Options) (*Manager, error) {
 	if cfg == nil {
 		return nil, errors.New("invalid configuration provided")
 	}
 
-	db, err := OpenDBConnection(DBOptions{
+	db, err := openDBConnection(dbOptions{
 		User:           cfg.Database.Username,
 		Password:       cfg.Database.Password,
 		Address:        cfg.Database.URL,
@@ -63,9 +43,12 @@ func Initialize(cfg *config.TemporalConfig, opts Options) (*Manager, error) {
 		return nil, err
 	}
 
+	if opts.Logger != nil {
+		db.SetLogger(opts.Logger)
+	}
 	db.LogMode(opts.LogMode)
 
-	dbm := Manager{DB: db}
+	var dbm = Manager{DB: db}
 	if opts.RunMigrations {
 		dbm.RunMigrations()
 	}
@@ -74,22 +57,26 @@ func Initialize(cfg *config.TemporalConfig, opts Options) (*Manager, error) {
 
 // RunMigrations runs all migrations
 func (dbm *Manager) RunMigrations() {
-	dbm.DB.AutoMigrate(UploadObj)
-	dbm.DB.AutoMigrate(UserObj)
-	dbm.DB.AutoMigrate(PaymentObj)
-	dbm.DB.AutoMigrate(IpnsObj)
-	dbm.DB.AutoMigrate(HostedIpfsNetObj)
-	dbm.DB.AutoMigrate(EncryptedUploadObj)
-	dbm.DB.AutoMigrate(TnsZoneObj)
-	dbm.DB.AutoMigrate(TnsRecordObj)
-	dbm.DB.AutoMigrate(UsagesRecordObj)
+	for _, t := range []interface{}{
+		&models.Upload{},
+		&models.EncryptedUpload{},
+		&models.User{},
+		&models.Payments{},
+		&models.IPNS{},
+		&models.HostedIPFSPrivateNetwork{},
+		&models.Zone{},
+		&models.Record{},
+		&models.Usage{},
+	} {
+		dbm.DB.AutoMigrate(t)
+	}
 }
 
 // Close shuts down database connection
 func (dbm *Manager) Close() error { return dbm.DB.Close() }
 
-// DBOptions declares options for opening a database connection
-type DBOptions struct {
+// dbOptions declares options for opening a database connection
+type dbOptions struct {
 	User           string
 	Password       string
 	Address        string
@@ -97,20 +84,21 @@ type DBOptions struct {
 	SSLModeDisable bool
 }
 
-// OpenDBConnection is used to create a database connection
-func OpenDBConnection(opts DBOptions) (*gorm.DB, error) {
+// openDBConnection is used to create a database connection
+func openDBConnection(opts dbOptions) (*gorm.DB, error) {
 	if opts.User == "" {
 		opts.User = "postgres"
 	}
-	// look into whether or not we wil disable sslmode
+
 	dbConnURL := fmt.Sprintf("host=%s port=%s user=%s dbname=temporal password=%s",
 		opts.Address, opts.Port, opts.User, opts.Password)
 	if opts.SSLModeDisable {
 		dbConnURL = "sslmode=disable " + dbConnURL
 	}
+
 	db, err := gorm.Open("postgres", dbConnURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to establish connection with database: %s", err.Error())
 	}
 	return db, nil
 }

--- a/log.go
+++ b/log.go
@@ -1,0 +1,37 @@
+package database
+
+import "go.uber.org/zap"
+
+// LogLevel indicates different logging levels
+type LogLevel string
+
+const (
+	// LogLevelInfo denotes info-level logging
+	LogLevelInfo LogLevel = "info"
+
+	// LogLevelDebug denotes debug-level logging
+	LogLevelDebug LogLevel = "debug"
+)
+
+// Logger defines the database's logging interface
+type Logger interface{ Print(...interface{}) }
+
+// PrintLogger wraps a single logFunc to implement the Logger interface
+type PrintLogger struct{ logFunc func(...interface{}) }
+
+// NewZapLogger wraps a zap logger in a PrintLogger
+func NewZapLogger(level LogLevel, l *zap.SugaredLogger) *PrintLogger {
+	var logFunc = func(...interface{}) {}
+	if l != nil {
+		switch level {
+		case LogLevelInfo:
+			logFunc = l.Info
+		case LogLevelDebug:
+			logFunc = l.Debug
+		}
+	}
+	return &PrintLogger{logFunc}
+}
+
+// Print logs the given message
+func (p *PrintLogger) Print(args ...interface{}) { p.logFunc(args...) }

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,14 @@
+package database
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestZapLogger(t *testing.T) {
+	var l = NewZapLogger(LogLevelInfo, zap.NewExample().Sugar())
+	l.Print("hello", "world")
+	l = NewZapLogger(LogLevelDebug, zap.NewExample().Sugar())
+	l.Print("goodbye", "world")
+}

--- a/models/db_test.go
+++ b/models/db_test.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/RTradeLtd/config"
+	"github.com/RTradeLtd/gorm"
+)
+
+type testLogger struct{ t *testing.T }
+
+func (t *testLogger) Print(args ...interface{}) { t.t.Log(args...) }
+
+func newTestDB(t *testing.T, model interface{}) *gorm.DB {
+	cfg, err := config.LoadConfig("../testenv/config.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := gorm.Open("postgres",
+		fmt.Sprintf("host=127.0.0.1 port=%s user=postgres dbname=temporal password=%s sslmode=disable",
+			cfg.Database.Port, cfg.Database.Password))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetLogger(&testLogger{t})
+	db.LogMode(true)
+
+	if model != nil {
+		if check := db.AutoMigrate(model); check.Error != nil {
+			t.Fatalf("could not execute migration for model '%+v': %s",
+				model, err.Error())
+		}
+	}
+
+	return db
+}
+
+func TestAutoMigrate(t *testing.T) {
+	type args struct {
+		model interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"encrypted upload", args{&EncryptedUpload{}}},
+		{"ipfs networks", args{&HostedIPFSPrivateNetwork{}}},
+		{"ipns", args{&IPNS{}}},
+		{"payment", args{&Payments{}}},
+		{"record", args{&Record{}}},
+		{"tns zone", args{&Zone{}}},
+		{"upload", args{&Upload{}}},
+		{"usage", args{&Usage{}}},
+		{"user", args{&User{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { newTestDB(t, tt.args.model) })
+	}
+}

--- a/models/encrypted_test.go
+++ b/models/encrypted_test.go
@@ -1,36 +1,11 @@
-package models_test
+package models
 
 import (
 	"testing"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
 )
 
-func TestMigration_EncryptedUpload(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if check := db.AutoMigrate(&models.EncryptedUpload{}); check.Error != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestEncryptedUploads(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ecm := models.NewEncryptedUploadManager(db)
+	var ecm = NewEncryptedUploadManager(newTestDB(t, &EncryptedUpload{}))
 	type args struct {
 		user    string
 		file    string

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -16,8 +16,9 @@ type HostedIPFSPrivateNetwork struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
-	Name      string    `gorm:"unique;type:varchar(255)"` // Name of the network node
-	Activated time.Time // Activated represents the most recent activation, 0-value if offline
+	Name      string     `gorm:"unique;type:varchar(255)"` // Name of the network node
+	Activated *time.Time // Activated represents the most recent activation, null if offline
+	Disabled  bool
 
 	PeerKey string // Private key used to generate peerID for this network node
 
@@ -114,6 +115,16 @@ func (im *IPFSNetworkManager) SaveNetwork(n *HostedIPFSPrivateNetwork) error {
 		return check.Error
 	}
 	return nil
+}
+
+// GetAllOfflineNetworks returns all currently offline networks
+func (im *IPFSNetworkManager) GetAllOfflineNetworks(disabled bool) ([]HostedIPFSPrivateNetwork, error) {
+	var networks = make([]HostedIPFSPrivateNetwork, 0)
+	var check = im.DB.Model(&HostedIPFSPrivateNetwork{}).
+		Where("activated = ?", nil).
+		Where("disabled = ?", disabled).
+		Find(&networks)
+	return networks, check.Error
 }
 
 // NetworkAccessOptions configures access to a hosted private network

--- a/models/ipfs_networks.go
+++ b/models/ipfs_networks.go
@@ -16,9 +16,8 @@ type HostedIPFSPrivateNetwork struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
-	Name      string     `gorm:"unique;type:varchar(255)"` // Name of the network node
-	Activated *time.Time // Activated represents the most recent activation, null if offline
-	Disabled  bool
+	Name      string    `gorm:"unique;type:varchar(255)"` // Name of the network node
+	Activated time.Time // Activated represents the most recent activation, null if offline
 
 	PeerKey string // Private key used to generate peerID for this network node
 
@@ -115,16 +114,6 @@ func (im *IPFSNetworkManager) SaveNetwork(n *HostedIPFSPrivateNetwork) error {
 		return check.Error
 	}
 	return nil
-}
-
-// GetAllOfflineNetworks returns all currently offline networks
-func (im *IPFSNetworkManager) GetAllOfflineNetworks(disabled bool) ([]HostedIPFSPrivateNetwork, error) {
-	var networks = make([]HostedIPFSPrivateNetwork, 0)
-	var check = im.DB.Model(&HostedIPFSPrivateNetwork{}).
-		Where("activated = ?", nil).
-		Where("disabled = ?", disabled).
-		Find(&networks)
-	return networks, check.Error
 }
 
 // NetworkAccessOptions configures access to a hosted private network

--- a/models/ipns_test.go
+++ b/models/ipns_test.go
@@ -1,13 +1,8 @@
-package models_test
+package models
 
 import (
-	"fmt"
 	"testing"
 	"time"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
-	"github.com/RTradeLtd/gorm"
 )
 
 const (
@@ -18,30 +13,8 @@ var (
 	testCfgPath = "../testenv/config.json"
 )
 
-func TestMigration_IPNS(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if check := db.AutoMigrate(&models.IPNS{}); check.Error != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestIpnsManager_NewEntry(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	im := models.NewIPNSManager(db)
+	var im = NewIPNSManager(newTestDB(t, &IPNS{}))
 	type args struct {
 		ipnsHash    string
 		ipfsHash    string
@@ -93,15 +66,7 @@ func TestIpnsManager_NewEntry(t *testing.T) {
 }
 
 func TestIpnsManager_UpdateEntry(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	im := models.NewIPNSManager(db)
+	var im = NewIPNSManager(newTestDB(t, &IPNS{}))
 	type args struct {
 		ipnsHash    string
 		ipfsHash    string
@@ -151,15 +116,7 @@ func TestIpnsManager_UpdateEntry(t *testing.T) {
 }
 
 func TestIpnsManager_FindByIPNSHash(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	im := models.NewIPNSManager(db)
+	var im = NewIPNSManager(newTestDB(t, &IPNS{}))
 	type args struct {
 		ipnsHash    string
 		ipfsHash    string
@@ -202,15 +159,7 @@ func TestIpnsManager_FindByIPNSHash(t *testing.T) {
 }
 
 func TestIpnsManager_FindByUser(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	im := models.NewIPNSManager(db)
+	var im = NewIPNSManager(newTestDB(t, &IPNS{}))
 	type args struct {
 		ipnsHash    string
 		ipfsHash    string
@@ -246,16 +195,4 @@ func TestIpnsManager_FindByUser(t *testing.T) {
 			}
 		})
 	}
-}
-
-func openDatabaseConnection(t *testing.T, cfg *config.TemporalConfig) (*gorm.DB, error) {
-	dbConnURL := fmt.Sprintf("host=127.0.0.1 port=%s user=postgres dbname=temporal password=%s sslmode=disable",
-		cfg.Database.Port, cfg.Database.Password)
-
-	db, err := gorm.Open("postgres", dbConnURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	//db.LogMode(true)
-	return db, nil
 }

--- a/models/payment_test.go
+++ b/models/payment_test.go
@@ -1,37 +1,11 @@
-package models_test
+package models
 
 import (
 	"testing"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
 )
 
-func TestMigration_Payment(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if check := db.AutoMigrate(&models.Payments{}); check.Error != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestPaymentManager_NewPayment(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pm := models.NewPaymentManager(db)
+	var pm = NewPaymentManager(newTestDB(t, &Payments{}))
 	type args struct {
 		depositAddress string
 		txHash         string

--- a/models/record_test.go
+++ b/models/record_test.go
@@ -1,36 +1,11 @@
-package models_test
+package models
 
 import (
 	"testing"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
 )
 
-func TestMigration_Record(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = db.AutoMigrate(&models.Record{}).Error; err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestRecord(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rm := models.NewRecordManager(db)
+	var rm = NewRecordManager(newTestDB(t, &Record{}))
 	type args struct {
 		username      string
 		recordName    string
@@ -61,7 +36,7 @@ func TestRecord(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer db.Delete(record1)
+			defer rm.DB.Delete(record1)
 			if record1.LatestIPFSHash != "" {
 				t.Fatal("latest ipfs hash should be empty")
 			}

--- a/models/tns_test.go
+++ b/models/tns_test.go
@@ -1,35 +1,11 @@
-package models_test
+package models
 
 import (
 	"testing"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
 )
 
-func TestMigration_TNS(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = db.AutoMigrate(&models.Zone{}).Error; err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestZone(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	var zm = NewZoneManager(newTestDB(t, &Zone{}))
 	args := struct {
 		username           string
 		zoneName           string
@@ -37,7 +13,6 @@ func TestZone(t *testing.T) {
 		zonePublicKeyName  string
 		ipfshash           string
 	}{"testuser", "testzone", "testzonemanager", "testzonepublic", "testhash"}
-	zm := models.NewZoneManager(db)
 	zone1, err := zm.NewZone(
 		args.username,
 		args.zoneName,
@@ -48,7 +23,7 @@ func TestZone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Delete(zone1)
+	defer zm.DB.Delete(zone1)
 	zone2, err := zm.FindZoneByNameAndUser(args.zoneName, args.username)
 	if err != nil {
 		t.Fatal(err)

--- a/models/upload_test.go
+++ b/models/upload_test.go
@@ -1,39 +1,14 @@
-package models_test
+package models
 
 import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
 )
 
-func TestMigration_Upload(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if check := db.AutoMigrate(&models.Upload{}); check.Error != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestExtendGCD(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUploadManager(db)
-	upload, err := um.NewUpload("testcontenthash", "file", models.UploadOptions{
+	var um = NewUploadManager(newTestDB(t, &Upload{}))
+	upload, err := um.NewUpload("testcontenthash", "file", UploadOptions{
 		NetworkName: "public",
 		Username:    "testuser1",
 		Encrypted:   false,
@@ -81,15 +56,7 @@ func TestExtendGCD(t *testing.T) {
 	}
 }
 func TestUpload(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUploadManager(db)
+	var um = NewUploadManager(newTestDB(t, &Upload{}))
 	type args struct {
 		hash       string
 		uploadType string
@@ -113,7 +80,7 @@ func TestUpload(t *testing.T) {
 			upload1, err := um.NewUpload(
 				tt.args.hash,
 				tt.args.uploadType,
-				models.UploadOptions{
+				UploadOptions{
 					NetworkName:      tt.args.network,
 					Username:         tt.args.userName1,
 					HoldTimeInMonths: tt.args.holdTime,
@@ -127,7 +94,7 @@ func TestUpload(t *testing.T) {
 			upload2, err := um.NewUpload(
 				tt.args.hash,
 				tt.args.uploadType,
-				models.UploadOptions{
+				UploadOptions{
 					NetworkName:      tt.args.network,
 					Username:         tt.args.userName2,
 					HoldTimeInMonths: tt.args.holdTime,
@@ -141,7 +108,7 @@ func TestUpload(t *testing.T) {
 			if _, err := um.NewUpload(
 				tt.args.hash,
 				tt.args.uploadType,
-				models.UploadOptions{
+				UploadOptions{
 					NetworkName:      tt.args.network,
 					Username:         tt.args.userName2,
 					HoldTimeInMonths: tt.args.holdTime,
@@ -149,13 +116,13 @@ func TestUpload(t *testing.T) {
 				},
 			); err == nil {
 				t.Fatal("expected error")
-			} else if err.Error() != models.ErrAlreadyExistingUpload {
+			} else if err.Error() != ErrAlreadyExistingUpload {
 				t.Fatal("wrong error message received")
 			}
 			// test update which triggers shorter gcd error
 			if _, err := um.UpdateUpload(1, tt.args.userName1, tt.args.hash, tt.args.network); err == nil {
 				t.Fatal("expected error")
-			} else if err.Error() != models.ErrShorterGCD {
+			} else if err.Error() != ErrShorterGCD {
 				t.Fatal("wrong error returned")
 			}
 			// test update which passes

--- a/models/usage_test.go
+++ b/models/usage_test.go
@@ -1,41 +1,16 @@
-package models_test
+package models
 
 import (
 	"testing"
 
 	"github.com/c2h5oh/datasize"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
 )
 
-func TestMigration_Usage(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if check := db.AutoMigrate(&models.Usage{}); check.Error != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestUsage(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	bm := models.NewUsageManager(db)
+	var bm = NewUsageManager(newTestDB(t, &Usage{}))
 	type args struct {
 		username       string
-		tier           models.DataUsageTier
+		tier           DataUsageTier
 		testUploadSize uint64
 	}
 	tests := []struct {
@@ -43,16 +18,16 @@ func TestUsage(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"Free", args{"free", models.Free, datasize.GB.Bytes()}, false},
-		{"Partner", args{"partner", models.Partner, datasize.GB.Bytes() * 10}, false},
-		{"Light", args{"light", models.Light, datasize.GB.Bytes() * 100}, false},
-		{"Plus", args{"plus", models.Plus, datasize.GB.Bytes() * 10}, false},
-		{"Fail", args{"fail", models.Free, 1}, true},
+		{"Free", args{"free", Free, datasize.GB.Bytes()}, false},
+		{"Partner", args{"partner", Partner, datasize.GB.Bytes() * 10}, false},
+		{"Light", args{"light", Light, datasize.GB.Bytes() * 100}, false},
+		{"Plus", args{"plus", Plus, datasize.GB.Bytes() * 10}, false},
+		{"Fail", args{"fail", Free, 1}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var (
-				usage *models.Usage
+				usage *Usage
 				err   error
 			)
 			if !tt.wantErr {
@@ -87,7 +62,7 @@ func TestUsage(t *testing.T) {
 			}
 			// test update tiers for all tier types
 			// an account may never enter free status once exiting
-			tiers := []models.DataUsageTier{models.Partner, models.Light, models.Plus}
+			tiers := []DataUsageTier{Partner, Light, Plus}
 			for _, tier := range tiers {
 				if err := bm.UpdateTier(tt.args.username, tier); (err != nil) != tt.wantErr {
 					t.Fatalf("UpdateTier() err = %v, wantErr %v", err, tt.wantErr)
@@ -100,7 +75,7 @@ func TestUsage(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if usage.Tier != models.Plus {
+				if usage.Tier != Plus {
 					t.Fatal("failed to correctly set usage tier")
 				}
 			}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -1,10 +1,7 @@
-package models_test
+package models
 
 import (
 	"testing"
-
-	"github.com/RTradeLtd/config"
-	"github.com/RTradeLtd/database/models"
 )
 
 var (
@@ -23,32 +20,8 @@ type args struct {
 	password string
 }
 
-func TestMigration_User(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if check := db.AutoMigrate(&models.User{}); check.Error != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestUserManager_NewAccount(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -69,16 +42,7 @@ func TestUserManager_NewAccount(t *testing.T) {
 }
 
 func TestUserManager_GetPrivateIPFSNetworksForUSer(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -87,7 +51,6 @@ func TestUserManager_GetPrivateIPFSNetworksForUSer(t *testing.T) {
 		{"Success", args{username, email, "password123"}, false},
 		{"Failure", args{"notarealuser", "notarealemail", "password123"}, true},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// add a private network for testing purposes
@@ -105,17 +68,7 @@ func TestUserManager_GetPrivateIPFSNetworksForUSer(t *testing.T) {
 }
 
 func TestUserManager_CheckIfUserHasAccessToNetwork(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -135,17 +88,7 @@ func TestUserManager_CheckIfUserHasAccessToNetwork(t *testing.T) {
 }
 
 func TestUserManager_AddandRemoveIPFSNetworkForUSer(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -169,7 +112,7 @@ func TestUserManager_AddandRemoveIPFSNetworkForUSer(t *testing.T) {
 			); (err != nil) != tt.wantErr {
 				t.Fatalf("CheckIfUserHasAccessToNetwork err = %v, want %v", err, tt.wantErr)
 			}
-			if err = um.RemoveIPFSNetworkForUser(
+			if err := um.RemoveIPFSNetworkForUser(
 				tt.args.userName,
 				testNetwork,
 			); (err != nil) != tt.wantErr {
@@ -180,16 +123,7 @@ func TestUserManager_AddandRemoveIPFSNetworkForUSer(t *testing.T) {
 }
 
 func TestUserManager_AddIPFSKeyForUser(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -213,16 +147,7 @@ func TestUserManager_AddIPFSKeyForUser(t *testing.T) {
 }
 
 func TestUserManager_GetKeysForUser(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -242,16 +167,7 @@ func TestUserManager_GetKeysForUser(t *testing.T) {
 }
 
 func TestUserManager_GetKeyIDByName(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	type args struct {
 		userName string
 		email    string
@@ -288,16 +204,7 @@ func TestUserManager_GetKeyIDByName(t *testing.T) {
 }
 
 func TestUserManager_CheckIfKeyOwnedByUser(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	type args struct {
 		userName string
 		email    string
@@ -337,17 +244,7 @@ func TestUserManager_CheckIfKeyOwnedByUser(t *testing.T) {
 }
 
 func TestUserManager_CheckIfAccountEnabled(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name        string
 		args        args
@@ -372,17 +269,7 @@ func TestUserManager_CheckIfAccountEnabled(t *testing.T) {
 }
 
 func TestUserManager_ChangePassword(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name        string
 		args        args
@@ -406,16 +293,7 @@ func TestUserManager_ChangePassword(t *testing.T) {
 }
 
 func TestUserManager_SignIn(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name      string
 		args      args
@@ -441,17 +319,7 @@ func TestUserManager_SignIn(t *testing.T) {
 }
 
 func TestUserManager_ComparePlaintextPasswordToHash(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name      string
 		args      args
@@ -479,17 +347,7 @@ func TestUserManager_ComparePlaintextPasswordToHash(t *testing.T) {
 }
 
 func TestUserManager_FindUserByUserName(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -513,17 +371,7 @@ func TestUserManager_FindUserByUserName(t *testing.T) {
 }
 
 func TestUserManager_Credits(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -532,7 +380,6 @@ func TestUserManager_Credits(t *testing.T) {
 		{"Success", args{username, email, "password123"}, false},
 		{"Failure", args{"notarealuser", "notarealemail", "password123"}, true},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			userCopy, err := um.AddCredits(
@@ -568,17 +415,7 @@ func TestUserManager_Credits(t *testing.T) {
 	}
 }
 func TestUserManager_ResetPassword(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
+	var um = NewUserManager(newTestDB(t, &User{}))
 	tests := []struct {
 		name    string
 		args    args
@@ -601,16 +438,7 @@ func TestUserManager_ResetPassword(t *testing.T) {
 }
 
 func TestUserManager_Customer_Hash(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	type newArgs struct {
 		args
 		firstHash  string
@@ -621,7 +449,7 @@ func TestUserManager_Customer_Hash(t *testing.T) {
 		args    newArgs
 		wantErr bool
 	}{
-		{"Success", newArgs{args{username, email, "password123"}, "firsthash", models.EmptyCustomerObjectHash}, false},
+		{"Success", newArgs{args{username, email, "password123"}, "firsthash", EmptyCustomerObjectHash}, false},
 		{"Failure", newArgs{args{"notarealusername", "notarealemail", "password123"}, "firsthash", "secondhash"}, true},
 	}
 	for _, tt := range tests {
@@ -629,7 +457,7 @@ func TestUserManager_Customer_Hash(t *testing.T) {
 			// test getting the default customer object hash
 			if hash, err := um.GetCustomerObjectHash(tt.args.userName); (err != nil) != tt.wantErr {
 				t.Fatalf("GetCustomerObjectHash err = %v, wantErr %v", err, tt.wantErr)
-			} else if !tt.wantErr && hash != models.EmptyCustomerObjectHash {
+			} else if !tt.wantErr && hash != EmptyCustomerObjectHash {
 				t.Fatal("failed to get correct customer object hash")
 			}
 			// test updating it
@@ -656,16 +484,7 @@ func TestUserManager_Customer_Hash(t *testing.T) {
 }
 
 func TestUserManager_RemoveIPFSKeys(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
+	var um = NewUserManager(newTestDB(t, &User{}))
 	type args struct {
 		userName string
 		email    string


### PR DESCRIPTION
* rename `Initialize` to idiomatic `New`
* get rid of direct database instantiation via `OpenDBConnection`
* add log wrapper for zap, and new option for providing a logger
* clean up tests

this PR is **behind** #28