### PR TITLE
Add Owner Field To Hosted Network Model

### DIFF
--- a/models/hosted_network.go
+++ b/models/hosted_network.go
@@ -43,6 +43,9 @@ type HostedNetwork struct {
 	ResourcesDiskGB   int
 	ResourcesMemoryGB int
 
+	// Owner is the creator of the private network, and is allowed to invoke
+	// administrative commands, such as network destruction.
+	Owner string `gorm:"type:text"`
 	// Users allowed to control this node. Includes API access.
 	Users pq.StringArray `gorm:"type:text[]"` // these are the users to which this IPFS network connection applies to specified by eth address
 }
@@ -129,6 +132,7 @@ func (im *HostedNetworkManager) GetOfflineNetworks(disabled bool) ([]*HostedNetw
 
 // NetworkAccessOptions configures access to a hosted private network
 type NetworkAccessOptions struct {
+	Owner            string
 	Users            []string
 	APIAllowedOrigin string
 	PublicGateway    bool
@@ -187,9 +191,10 @@ func (im *HostedNetworkManager) CreateHostedPrivateNetwork(
 		for _, v := range access.Users {
 			pnet.Users = append(pnet.Users, v)
 		}
-	} else {
-		pnet.Users = append(pnet.Users, AdminAddress)
 	}
+
+	// set the owner of the network
+	pnet.Owner = access.Owner
 
 	// assign misc details
 	pnet.Name = name

--- a/models/hosted_network.go
+++ b/models/hosted_network.go
@@ -45,7 +45,7 @@ type HostedNetwork struct {
 
 	// Owner is the creator of the private network, and is allowed to invoke
 	// administrative commands, such as network destruction.
-	Owners []string `gorm:"type:text[]"`
+	Owners pq.StringArray `gorm:"type:text[]"`
 	// Users allowed to control this node. Includes API access.
 	Users pq.StringArray `gorm:"type:text[]"` // these are the users to which this IPFS network connection applies to specified by eth address
 }

--- a/models/hosted_network.go
+++ b/models/hosted_network.go
@@ -45,7 +45,7 @@ type HostedNetwork struct {
 
 	// Owner is the creator of the private network, and is allowed to invoke
 	// administrative commands, such as network destruction.
-	Owner string `gorm:"type:text"`
+	Owners []string `gorm:"type:text[]"`
 	// Users allowed to control this node. Includes API access.
 	Users pq.StringArray `gorm:"type:text[]"` // these are the users to which this IPFS network connection applies to specified by eth address
 }
@@ -194,7 +194,7 @@ func (im *HostedNetworkManager) CreateHostedPrivateNetwork(
 	}
 
 	// set the owner of the network
-	pnet.Owner = access.Owner
+	pnet.Owners = []string{access.Owner}
 
 	// assign misc details
 	pnet.Name = name

--- a/models/hosted_network_test.go
+++ b/models/hosted_network_test.go
@@ -8,7 +8,7 @@ import (
 func TestHostedNetworkManager_Access(t *testing.T) {
 	var hm = NewHostedNetworkManager(newTestDB(t, &HostedNetwork{}))
 	defer hm.DB.Close()
-	if network, err := hm.CreateHostedPrivateNetwork(
+	network, err := hm.CreateHostedPrivateNetwork(
 		"myveryrandomnetworkname",
 		"such swarm much protec",
 		nil,
@@ -16,10 +16,20 @@ func TestHostedNetworkManager_Access(t *testing.T) {
 			Owner: "testuserguy1",
 			Users: []string{"testuserguy1", "testuserguy2"},
 		},
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatal(err)
-	} else if network.Owner != "testuserguy1" {
-		t.Fatal("failed to correctly set network owner")
+	}
+	defer hm.Delete("myveryrandomnetworkname")
+	var found bool
+	for _, owner := range network.Owners {
+		if owner == "testuserguy1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("failed to correctly set network owner during creation")
 	}
 }
 

--- a/models/hosted_network_test.go
+++ b/models/hosted_network_test.go
@@ -5,6 +5,24 @@ import (
 	"time"
 )
 
+func TestHostedNetworkManager_Access(t *testing.T) {
+	var hm = NewHostedNetworkManager(newTestDB(t, &HostedNetwork{}))
+	defer hm.DB.Close()
+	if network, err := hm.CreateHostedPrivateNetwork(
+		"myveryrandomnetworkname",
+		"such swarm much protec",
+		nil,
+		NetworkAccessOptions{
+			Owner: "testuserguy1",
+			Users: []string{"testuserguy1", "testuserguy2"},
+		},
+	); err != nil {
+		t.Fatal(err)
+	} else if network.Owner != "testuserguy1" {
+		t.Fatal("failed to correctly set network owner")
+	}
+}
+
 func TestHostedNetworkManager_GetOfflineNetworks(t *testing.T) {
 	var hm = NewHostedNetworkManager(newTestDB(t, &HostedNetwork{}))
 	defer hm.DB.Close()


### PR DESCRIPTION
In order to enable restriction around administrative commands for private networks, an `Owner` field was added. This will allow us to restrict who can delete a network, update authorized users, and perform other administrative functionality to just the owner.