### PR TITLE
Tier + Pricing Revamp

### DIFF
--- a/models/usage.go
+++ b/models/usage.go
@@ -351,17 +351,17 @@ func (bm *UsageManager) IncrementKeyCount(username string, count int64) error {
 }
 
 // ResetCounts is used to reset monthly usage counts.
-// This does not apply to keys, as keys are a fixed limitation
+// This does not apply to keys created as that is a fixed limit.
+// Instead, it applies to rate-limited features as as IPNS
+// record publishing, and sending of PubSub messages
 func (bm *UsageManager) ResetCounts(username string) error {
 	b, err := bm.FindByUserName(username)
 	if err != nil {
 		return err
 	}
-	b.CurrentDataUsedBytes = 0
 	b.IPNSRecordsPublished = 0
 	b.PubSubMessagesSent = 0
 	return bm.DB.Model(b).UpdateColumns(map[string]interface{}{
-		"current_data_used_bytes": b.CurrentDataUsedBytes,
 		"ip_ns_records_published": b.IPNSRecordsPublished,
 		"pub_sub_messages_sent":   b.PubSubMessagesSent,
 	}).Error

--- a/models/usage.go
+++ b/models/usage.go
@@ -259,7 +259,7 @@ func (bm *UsageManager) ReduceKeyCount(username string, count int64) error {
 	if err != nil {
 		return err
 	}
-	if b.KeysCreated > count {
+	if b.KeysCreated < count {
 		b.KeysCreated = 0
 	} else {
 		b.KeysCreated = b.KeysCreated - count

--- a/models/usage.go
+++ b/models/usage.go
@@ -20,12 +20,10 @@ func (d DataUsageTier) String() string {
 // PricePerGB returns the price per gb of a usage tier
 func (d DataUsageTier) PricePerGB() float64 {
 	switch d {
-	case Light:
-		return 0.22
-	case Plus:
-		return 0.165
+	case Paid:
+		return 0.07
 	case Partner:
-		return 0.16
+		return 0.05
 	default:
 		// this is a catch-all for free tier
 		// free tier users will never encounter a charge call
@@ -42,37 +40,24 @@ var (
 	//			* 5 keys
 	Free DataUsageTier = "free"
 
+	// Paid is the non-free tier of Temporal
+	// Maximum data-limit is 1TB/month
+	//			* on-demand data encryption
+	Paid DataUsageTier = "paid"
+
 	// Partner is for partners of RTrade
 	// partners have 100GB/month free
 	//			* on-demand data encryption
 	//			* 0.16GB/month after 100GB limit
 	Partner DataUsageTier = "partner"
 
-	// Light is the first non-free, and non-partner tier
-	// tier is from 3GB -> 100GB
-	// after reaching 100GB they are upgraded to Plus
-	//			* on-demand data encryption
-	//			* 0.22
-	Light DataUsageTier = "light"
-
-	// Plus is the other non-free, non-partner, non-light tier
-	// tier is from 100GB -> 1TB to our max monthly usage of 1TB
-	// 			* on-demand data encryption
-	//			* $0.165
-	Plus DataUsageTier = "plus"
-
 	// FreeUploadLimit is the maximum data usage for free accounts
 	// Currrently set to 3GB
 	FreeUploadLimit = 3 * datasize.GB.Bytes()
 
 	// NonFreeUploadLimit is the maximum data usage for non-free accounts
-	// Currently set to 1TB
-	NonFreeUploadLimit = datasize.TB.Bytes()
-
-	// PlusTierMinimumUpload is the current data usage
-	// needed to upgrade from Light -> Plus
-	// currently set to 100GB
-	PlusTierMinimumUpload = 100 * datasize.GB.Bytes()
+	// Currently set to 1000TB
+	NonFreeUploadLimit = datasize.TB.Bytes() * 1000
 
 	// FreeKeyLimit defines how many keys free accounts can create
 	FreeKeyLimit int64 = 5
@@ -81,26 +66,19 @@ var (
 	// FreeIPNSLimit defines how many ipns records free accounts can publish
 	FreeIPNSLimit int64 = 5
 
+	// PaidKeyLimit defines how many keys plus accounts can create
+	PaidKeyLimit int64 = 150
+	// PaidPubSubLimit defines how many pubsub messages plus accounts can send
+	PaidPubSubLimit int64 = 15000
+	// PaidIPNSRecordLimit defines how many ipns records plus accounts can publish
+	PaidIPNSRecordLimit int64 = 150
+
 	// PartnerKeyLimit defines how many keys partner accounts can create
 	PartnerKeyLimit int64 = 200
 	// PartnerPubSubLimit defines how many pubsub messages partner accounts can send
 	PartnerPubSubLimit int64 = 20000
 	// PartnerIPNSLimit defines how many ipns records partner accounts can publish
 	PartnerIPNSLimit int64 = 200
-
-	// LightKeyLimit defines how many keys light accounts can create
-	LightKeyLimit int64 = 100
-	// LightPubSubLimit defines how many pubsub messages light accounts can send
-	LightPubSubLimit int64 = 10000
-	// LightIPNSLimit defines how many ipns records light accounts can publish
-	LightIPNSLimit int64 = 100
-
-	// PlusKeyLimit defines how many keys plus accounts can create
-	PlusKeyLimit int64 = 150
-	// PlusPubSubLimit defines how many pubsub messages plus accounts can send
-	PlusPubSubLimit int64 = 15000
-	// PlusIPNSRecordLimit defines how many ipns records plus accounts can publish
-	PlusIPNSRecordLimit int64 = 150
 )
 
 // Usage is used to handle Usage of Temporal accounts
@@ -141,11 +119,8 @@ func NewUsageManager(db *gorm.DB) *UsageManager {
 // if tier is free, limit to 3GB monthly otherwise set to 1TB
 func (bm *UsageManager) NewUsageEntry(username string, tier DataUsageTier) (*Usage, error) {
 	usage := &Usage{
-		UserName:             username,
-		CurrentDataUsedBytes: 0,
-		IPNSRecordsPublished: 0,
-		PubSubMessagesSent:   0,
-		Tier:                 tier,
+		UserName: username,
+		Tier:     tier,
 	}
 	// set tier
 	usage.Tier = tier
@@ -161,16 +136,11 @@ func (bm *UsageManager) NewUsageEntry(username string, tier DataUsageTier) (*Usa
 		usage.KeysAllowed = PartnerKeyLimit
 		usage.PubSubMessagesAllowed = PartnerPubSubLimit
 		usage.IPNSRecordsAllowed = PartnerIPNSLimit
-	case Light:
+	case Paid:
 		usage.MonthlyDataLimitBytes = NonFreeUploadLimit
-		usage.KeysAllowed = LightKeyLimit
-		usage.PubSubMessagesAllowed = LightPubSubLimit
-		usage.IPNSRecordsAllowed = LightIPNSLimit
-	case Plus:
-		usage.MonthlyDataLimitBytes = NonFreeUploadLimit
-		usage.KeysAllowed = PlusKeyLimit
-		usage.PubSubMessagesAllowed = PlusPubSubLimit
-		usage.IPNSRecordsAllowed = PlusIPNSRecordLimit
+		usage.KeysAllowed = PaidKeyLimit
+		usage.PubSubMessagesAllowed = PaidPubSubLimit
+		usage.IPNSRecordsAllowed = PaidIPNSRecordLimit
 	default:
 		return nil, errors.New("unsupported tier provided")
 	}
@@ -259,19 +229,6 @@ func (bm *UsageManager) UpdateDataUsage(username string, uploadSizeBytes uint64)
 	}
 	// update total data used
 	b.CurrentDataUsedBytes = b.CurrentDataUsedBytes + uploadSizeBytes
-	// perform a tier check for light accounts
-	// if they use more than 100GB, upgrade them to Plus tier
-	if b.Tier == Light {
-		// if they are light plan, and this upload takes them over 100GB
-		// update their tier to plus, enabling cheaper data rates
-		if b.CurrentDataUsedBytes >= PlusTierMinimumUpload {
-			// update tier
-			b.Tier = Plus
-			b.KeysAllowed = PlusKeyLimit
-			b.PubSubMessagesAllowed = PlusPubSubLimit
-			b.IPNSRecordsAllowed = PlusIPNSRecordLimit
-		}
-	}
 	// perform upload limit checks
 	if b.Tier == Free {
 		// if they are free, they will need to upgrade their plan
@@ -309,16 +266,6 @@ func (bm *UsageManager) ReduceDataUsage(username string, uploadSizeBytes uint64)
 	} else {
 		b.CurrentDataUsedBytes = b.CurrentDataUsedBytes - uploadSizeBytes
 	}
-	// perform tier downgrade check
-	// accounts can never be downgraded below Light to free tier
-	if b.Tier == Plus {
-		if b.CurrentDataUsedBytes < PlusTierMinimumUpload {
-			b.Tier = Light
-			b.KeysAllowed = LightKeyLimit
-			b.IPNSRecordsAllowed = LightIPNSLimit
-			b.PubSubMessagesAllowed = LightPubSubLimit
-		}
-	}
 	return bm.DB.Model(b).UpdateColumns(map[string]interface{}{
 		"tier":                    b.Tier,
 		"current_data_used_Bytes": b.CurrentDataUsedBytes,
@@ -355,16 +302,11 @@ func (bm *UsageManager) UpdateTier(username string, tier DataUsageTier) error {
 		b.KeysAllowed = PartnerKeyLimit
 		b.PubSubMessagesAllowed = PartnerPubSubLimit
 		b.IPNSRecordsAllowed = PartnerIPNSLimit
-	case Light:
+	case Paid:
 		b.MonthlyDataLimitBytes = NonFreeUploadLimit
-		b.KeysAllowed = LightKeyLimit
-		b.PubSubMessagesAllowed = LightPubSubLimit
-		b.IPNSRecordsAllowed = LightIPNSLimit
-	case Plus:
-		b.MonthlyDataLimitBytes = NonFreeUploadLimit
-		b.KeysAllowed = PlusKeyLimit
-		b.PubSubMessagesAllowed = PlusPubSubLimit
-		b.IPNSRecordsAllowed = PlusIPNSRecordLimit
+		b.KeysAllowed = PaidKeyLimit
+		b.PubSubMessagesAllowed = PaidPubSubLimit
+		b.IPNSRecordsAllowed = PaidIPNSRecordLimit
 	default:
 		return errors.New("unsupported tier provided")
 	}

--- a/models/usage.go
+++ b/models/usage.go
@@ -181,18 +181,6 @@ func (bm *UsageManager) CanPublishIPNS(username string) error {
 	return nil
 }
 
-// CanUpload is used to check if a user can upload an object with the given data size
-func (bm *UsageManager) CanUpload(username string, dataSizeBytes uint64) error {
-	b, err := bm.FindByUserName(username)
-	if err != nil {
-		return err
-	}
-	if b.CurrentDataUsedBytes+dataSizeBytes > b.MonthlyDataLimitBytes {
-		return errors.New("upload will breach max monthly data usage, please upload a smaller file")
-	}
-	return nil
-}
-
 // CanPublishPubSub is used to check if a user can publish pubsub messages
 func (bm *UsageManager) CanPublishPubSub(username string) error {
 	b, err := bm.FindByUserName(username)

--- a/models/usage.go
+++ b/models/usage.go
@@ -179,7 +179,7 @@ func (bm *UsageManager) CanPublishIPNS(username string) error {
 		return err
 	}
 	if b.IPNSRecordsPublished >= b.IPNSRecordsAllowed {
-		return errors.New("too many records published")
+		return errors.New("too many records published, please wait until next billing cycle")
 	}
 	return nil
 }
@@ -203,7 +203,7 @@ func (bm *UsageManager) CanCreateKey(username string) error {
 		return err
 	}
 	if b.KeysCreated >= b.KeysAllowed {
-		return errors.New("too many keys created, please wait until next billing cycle")
+		return errors.New("too many keys created")
 	}
 	return nil
 }

--- a/models/usage.go
+++ b/models/usage.go
@@ -249,8 +249,7 @@ func (bm *UsageManager) ReduceDataUsage(username string, uploadSizeBytes uint64)
 		b.CurrentDataUsedBytes = b.CurrentDataUsedBytes - uploadSizeBytes
 	}
 	return bm.DB.Model(b).UpdateColumns(map[string]interface{}{
-		"tier":                    b.Tier,
-		"current_data_used_Bytes": b.CurrentDataUsedBytes,
+		"current_data_used_bytes": b.CurrentDataUsedBytes,
 	}).Error
 }
 

--- a/models/usage.go
+++ b/models/usage.go
@@ -56,7 +56,10 @@ var (
 	FreeUploadLimit = 3 * datasize.GB.Bytes()
 
 	// NonFreeUploadLimit is the maximum data usage for non-free accounts
-	// Currently set to 1000TB
+	// Currently set to 1000TB or 1PB.
+	// We dont impose a usage limit to non-free accounts
+	// but since usage limit checking is needed for free
+	// accounts, we set an artificial limit.
 	NonFreeUploadLimit = datasize.TB.Bytes() * 1000
 
 	// FreeKeyLimit defines how many keys free accounts can create
@@ -223,19 +226,10 @@ func (bm *UsageManager) UpdateDataUsage(username string, uploadSizeBytes uint64)
 		if b.CurrentDataUsedBytes >= FreeUploadLimit {
 			return errors.New("upload limit will be reached, please upload smaller content or upgrade your plan")
 		}
-	} else {
-		// check for the max upload limit of 1TB
-		if b.CurrentDataUsedBytes >= NonFreeUploadLimit {
-			return errors.New("max upload limit of 1TB reached, contact support")
-		}
 	}
 	// save updated columns and return
 	return bm.DB.Model(b).UpdateColumns(map[string]interface{}{
-		"tier":                     b.Tier,
-		"current_data_used_bytes":  b.CurrentDataUsedBytes,
-		"keys_allowed":             b.KeysAllowed,
-		"ip_ns_records_allowed":    b.IPNSRecordsAllowed,
-		"pub_sub_messages_allowed": b.PubSubMessagesAllowed,
+		"current_data_used_bytes": b.CurrentDataUsedBytes,
 	}).Error
 }
 

--- a/models/usage_test.go
+++ b/models/usage_test.go
@@ -114,9 +114,7 @@ func TestUsage(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if usage.CurrentDataUsedBytes != 0 ||
-					usage.IPNSRecordsPublished != 0 ||
-					usage.PubSubMessagesSent != 0 {
+				if usage.IPNSRecordsPublished != 0 || usage.PubSubMessagesSent != 0 {
 					t.Fatal("should be 0")
 				}
 			}

--- a/models/usage_test.go
+++ b/models/usage_test.go
@@ -219,3 +219,38 @@ func Test_ReduceDataUsage(t *testing.T) {
 		t.Fatal("bad reduction in datasize")
 	}
 }
+
+func Test_ReduceKeyCount(t *testing.T) {
+	var bm = NewUsageManager(newTestDB(t, &Usage{}))
+	b, err := bm.NewUsageEntry("testuser", Paid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bm.DB.Unscoped().Delete(b)
+	if b.Tier != Paid {
+		t.Fatal("bad tier set")
+	}
+	if err := bm.IncrementKeyCount("testuser", 5); err != nil {
+		t.Fatal(err)
+	}
+	if err := bm.ReduceKeyCount("testuser", 4); err != nil {
+		t.Fatal(err)
+	}
+	b, err = bm.FindByUserName("testuser")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.KeysCreated != 1 {
+		t.Fatal("bad key count")
+	}
+	if err := bm.ReduceKeyCount("testuser", 3); err != nil {
+		t.Fatal(err)
+	}
+	b, err = bm.FindByUserName("testuser")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.KeysCreated != 0 {
+		t.Fatal("bad key count")
+	}
+}

--- a/models/usage_test.go
+++ b/models/usage_test.go
@@ -203,6 +203,9 @@ func Test_ReduceDataUsage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if b.CurrentDataUsedBytes != datasize.GB.Bytes()+datasize.MB.Bytes()*100 {
+		t.Fatal("bad datasize")
+	}
 	currentSize := b.CurrentDataUsedBytes
 	expectedSize := b.CurrentDataUsedBytes - datasize.MB.Bytes()*100
 	if err := bm.ReduceDataUsage("testuser", datasize.MB.Bytes()*100); err != nil {

--- a/models/usage_test.go
+++ b/models/usage_test.go
@@ -106,6 +106,20 @@ func TestUsage(t *testing.T) {
 					t.Fatal("failed to count ipns usage")
 				}
 			}
+			if !tt.wantErr {
+				if err := bm.ResetCounts(tt.args.username); err != nil {
+					t.Fatal(err)
+				}
+				usage, err := bm.FindByUserName(tt.args.username)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if usage.CurrentDataUsedBytes != 0 ||
+					usage.IPNSRecordsPublished != 0 ||
+					usage.PubSubMessagesSent != 0 {
+					t.Fatal("should be 0")
+				}
+			}
 		})
 	}
 }

--- a/models/usage_test.go
+++ b/models/usage_test.go
@@ -20,8 +20,7 @@ func TestUsage(t *testing.T) {
 	}{
 		{"Free", args{"free", Free, datasize.GB.Bytes()}, false},
 		{"Partner", args{"partner", Partner, datasize.GB.Bytes() * 10}, false},
-		{"Light", args{"light", Light, datasize.GB.Bytes() * 100}, false},
-		{"Plus", args{"plus", Plus, datasize.GB.Bytes() * 10}, false},
+		{"Paid", args{"paid", Paid, datasize.GB.Bytes() * 100}, false},
 		{"Fail", args{"fail", Free, 1}, true},
 	}
 	for _, tt := range tests {
@@ -62,20 +61,20 @@ func TestUsage(t *testing.T) {
 			}
 			// test update tiers for all tier types
 			// an account may never enter free status once exiting
-			tiers := []DataUsageTier{Partner, Light, Plus}
+			tiers := []DataUsageTier{Partner, Paid}
 			for _, tier := range tiers {
 				if err := bm.UpdateTier(tt.args.username, tier); (err != nil) != tt.wantErr {
 					t.Fatalf("UpdateTier() err = %v, wantErr %v", err, tt.wantErr)
 				}
 			}
 			// test that the light tier was upgraded
-			if tt.name == "Light" && !tt.wantErr {
+			if tt.name == "Paid" && !tt.wantErr {
 				// validate that the tier was upgraded
 				usage, err = bm.FindByUserName(tt.args.username)
 				if err != nil {
 					t.Fatal(err)
 				}
-				if usage.Tier != Plus {
+				if usage.Tier != Partner {
 					t.Fatal("failed to correctly set usage tier")
 				}
 			}
@@ -123,14 +122,14 @@ func Test_Tier_Upgrade(t *testing.T) {
 	if b.MonthlyDataLimitBytes != FreeUploadLimit {
 		t.Fatal("bad upload limit set")
 	}
-	if err := bm.UpdateTier("testuser", Light); err != nil {
+	if err := bm.UpdateTier("testuser", Paid); err != nil {
 		t.Fatal(err)
 	}
 	b, err = bm.FindByUserName("testuser")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if b.Tier != Light {
+	if b.Tier != Paid {
 		t.Fatal("bad tier set")
 	}
 	if b.MonthlyDataLimitBytes != NonFreeUploadLimit {

--- a/models/usage_test.go
+++ b/models/usage_test.go
@@ -61,7 +61,7 @@ func TestUsage(t *testing.T) {
 			}
 			// test update tiers for all tier types
 			// an account may never enter free status once exiting
-			tiers := []DataUsageTier{Partner, Paid}
+			tiers := []DataUsageTier{Paid, Partner}
 			for _, tier := range tiers {
 				if err := bm.UpdateTier(tt.args.username, tier); (err != nil) != tt.wantErr {
 					t.Fatalf("UpdateTier() err = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
* Fix a few bugs when reducing data usage limits, key counts
* Refactor pricing strategy to include Free+Paid tiers, with a paid tier data rate of $0.07/gb
* Free tier restrictions still the same
* Adjust error messages in usability checks
* Remove excessive db calls
* Paid tier inherits all features of Plus tier