### PR TITLE
Fix Occasionnal Pipe Closures

### DIFF
--- a/database.go
+++ b/database.go
@@ -3,6 +3,7 @@ package database
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/RTradeLtd/config/v2"
 	"github.com/RTradeLtd/database/v2/models"
@@ -100,5 +101,6 @@ func openDBConnection(opts dbOptions) (*gorm.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish connection with database: %s", err.Error())
 	}
+	db.DB().SetConnMaxLifetime(time.Minute * 60)
 	return db, nil
 }


### PR DESCRIPTION
Been doing some research into occasional errors the database package is getting involving "write: broken pipe" errors. Doing some research it appears that the max connection lifetime is the source:

https://github.com/go-sql-driver/mysql/issues/446
https://github.com/go-sql-driver/mysql/pull/934

This PR attempts to address the issue by setting the maximum connection lifetime to 60 minutes.