### PR TITLE
Enable Optional File Name Flag

### DIFF
--- a/models/upload.go
+++ b/models/upload.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/RTradeLtd/database/v2/utils"
@@ -29,7 +30,8 @@ type Upload struct {
 	HoldTimeInMonths   int64  `gorm:"type:integer;not null;"`
 	UserName           string `gorm:"type:varchar(255);not null;"`
 	GarbageCollectDate time.Time
-	Encrypted          bool `gorm:"type:bool"`
+	Encrypted          bool   `gorm:"type:bool"`
+	FileNameLowerCase  string `gorm:"type:varchar(255)"`
 }
 
 // UploadManager is used to manipulate upload objects in the database
@@ -46,6 +48,7 @@ func NewUploadManager(db *gorm.DB) *UploadManager {
 type UploadOptions struct {
 	NetworkName      string
 	Username         string
+	FileName         string
 	HoldTimeInMonths int64
 	Encrypted        bool
 }
@@ -69,6 +72,7 @@ func (um *UploadManager) NewUpload(contentHash, uploadType string, opts UploadOp
 		UserName:           opts.Username,
 		GarbageCollectDate: utils.CalculateGarbageCollectDate(holdInt),
 		Encrypted:          opts.Encrypted,
+		FileNameLowerCase:  strings.ToLower(opts.FileName),
 	}
 	if check := um.DB.Create(&upload); check.Error != nil {
 		return nil, check.Error

--- a/models/upload.go
+++ b/models/upload.go
@@ -31,7 +31,9 @@ type Upload struct {
 	UserName           string `gorm:"type:varchar(255);not null;"`
 	GarbageCollectDate time.Time
 	Encrypted          bool   `gorm:"type:bool"`
+	FileName           string `gorm:"type:varchar(255)"`
 	FileNameLowerCase  string `gorm:"type:varchar(255)"`
+	FileNameUpperCase  string `gorm:"type:varchar(255)"`
 }
 
 // UploadManager is used to manipulate upload objects in the database
@@ -72,7 +74,9 @@ func (um *UploadManager) NewUpload(contentHash, uploadType string, opts UploadOp
 		UserName:           opts.Username,
 		GarbageCollectDate: utils.CalculateGarbageCollectDate(holdInt),
 		Encrypted:          opts.Encrypted,
+		FileName:           opts.FileName,
 		FileNameLowerCase:  strings.ToLower(opts.FileName),
+		FileNameUpperCase:  strings.ToUpper(opts.FileName),
 	}
 	if check := um.DB.Create(&upload); check.Error != nil {
 		return nil, check.Error

--- a/models/upload_test.go
+++ b/models/upload_test.go
@@ -59,6 +59,7 @@ func TestUpload(t *testing.T) {
 	var um = NewUploadManager(newTestDB(t, &Upload{}))
 	type args struct {
 		hash       string
+		fileName   string
 		uploadType string
 		network    string
 		holdTime   int64
@@ -73,7 +74,7 @@ func TestUpload(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"User1-Hash1", args{"hash1", "file", "public", 5, "user1", "user2", time.Now(), time.Now().Add(time.Hour * 24), false}, false},
+		{"User1-Hash1", args{"hash1", "fileName", "file", "public", 5, "user1", "user2", time.Now(), time.Now().Add(time.Hour * 24), false}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -81,6 +82,7 @@ func TestUpload(t *testing.T) {
 				tt.args.hash,
 				tt.args.uploadType,
 				UploadOptions{
+					FileName:         tt.args.fileName,
 					NetworkName:      tt.args.network,
 					Username:         tt.args.userName1,
 					HoldTimeInMonths: tt.args.holdTime,
@@ -95,6 +97,7 @@ func TestUpload(t *testing.T) {
 				tt.args.hash,
 				tt.args.uploadType,
 				UploadOptions{
+					FileName:         tt.args.fileName,
 					NetworkName:      tt.args.network,
 					Username:         tt.args.userName2,
 					HoldTimeInMonths: tt.args.holdTime,
@@ -109,6 +112,7 @@ func TestUpload(t *testing.T) {
 				tt.args.hash,
 				tt.args.uploadType,
 				UploadOptions{
+					FileName:         tt.args.fileName,
 					NetworkName:      tt.args.network,
 					Username:         tt.args.userName2,
 					HoldTimeInMonths: tt.args.holdTime,

--- a/models/upload_test.go
+++ b/models/upload_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -92,7 +93,13 @@ func TestUpload(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if upload1.FileNameLowerCase != tt.args.fileName {
+			if upload1.FileName != tt.args.fileName {
+				t.Fatal("bad file name")
+			}
+			if upload1.FileNameUpperCase != strings.ToUpper(tt.args.fileName) {
+				t.Fatal("bad file name")
+			}
+			if upload1.FileNameLowerCase != strings.ToLower(tt.args.fileName) {
 				t.Fatal("bad file name")
 			}
 			defer um.DB.Unscoped().Delete(upload1)
@@ -110,7 +117,13 @@ func TestUpload(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if upload2.FileNameLowerCase != tt.args.fileName {
+			if upload2.FileName != tt.args.fileName {
+				t.Fatal("bad file name")
+			}
+			if upload2.FileNameUpperCase != strings.ToUpper(tt.args.fileName) {
+				t.Fatal("bad file name")
+			}
+			if upload2.FileNameLowerCase != strings.ToLower(tt.args.fileName) {
 				t.Fatal("bad file name")
 			}
 			defer um.DB.Unscoped().Delete(upload2)

--- a/models/upload_test.go
+++ b/models/upload_test.go
@@ -92,6 +92,9 @@ func TestUpload(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if upload1.FileNameLowerCase != tt.args.fileName {
+				t.Fatal("bad file name")
+			}
 			defer um.DB.Unscoped().Delete(upload1)
 			upload2, err := um.NewUpload(
 				tt.args.hash,
@@ -106,6 +109,9 @@ func TestUpload(t *testing.T) {
 			)
 			if err != nil {
 				t.Fatal(err)
+			}
+			if upload2.FileNameLowerCase != tt.args.fileName {
+				t.Fatal("bad file name")
 			}
 			defer um.DB.Unscoped().Delete(upload2)
 			if _, err := um.NewUpload(


### PR DESCRIPTION
This is to accomodate changes with the revamped playground and no longer using mongodb for storing filename. When we eventually move to the new playground we will need to migrate the existing filename data from mongodb to postgresql to be compatible with the new webui.

It enables storing of file name information associated with uploads.