### PR TITLE
Enables Marking Uploads As Being A Directory Upload

### DIFF
--- a/models/upload.go
+++ b/models/upload.go
@@ -37,6 +37,7 @@ type Upload struct {
 	FileNameUpperCase  string `gorm:"type:varchar(255)"`
 	Extension          string `gorm:"type:varchar(255)"`
 	Size               int64  `gorm:"type:integer"` // upload size in bytes
+	Directory          bool   `gorm:"type:bool;default:false"`
 }
 
 // UploadManager is used to manipulate upload objects in the database
@@ -57,6 +58,7 @@ type UploadOptions struct {
 	HoldTimeInMonths int64
 	Size             int64
 	Encrypted        bool
+	Directory        bool
 }
 
 // NewUpload is used to create a new upload in the database
@@ -83,6 +85,7 @@ func (um *UploadManager) NewUpload(contentHash, uploadType string, opts UploadOp
 		FileNameUpperCase:  strings.ToUpper(opts.FileName),
 		Extension:          filepath.Ext(opts.FileName),
 		Size:               opts.Size,
+		Directory:          opts.Directory,
 	}
 	if check := um.DB.Create(&upload); check.Error != nil {
 		return nil, check.Error

--- a/models/upload_test.go
+++ b/models/upload_test.go
@@ -73,12 +73,14 @@ func TestUpload(t *testing.T) {
 		newGCD     time.Time
 		encrypted  bool
 		size       int64
+		directory  bool
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 		wantExt string
+		wantDir bool
 	}{
 		{"User1-Hash1", args{
 			"hash1",
@@ -92,7 +94,8 @@ func TestUpload(t *testing.T) {
 			time.Now().Add(time.Hour * 24),
 			false,
 			100,
-		}, false, ".png"},
+			false,
+		}, false, ".png", false},
 		{"User1-Hash2", args{
 			"hash2",
 			"",
@@ -105,7 +108,8 @@ func TestUpload(t *testing.T) {
 			time.Now().Add(time.Hour * 24),
 			false,
 			100,
-		}, false, ""},
+			true,
+		}, false, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -119,6 +123,7 @@ func TestUpload(t *testing.T) {
 					HoldTimeInMonths: tt.args.holdTime,
 					Encrypted:        tt.args.encrypted,
 					Size:             tt.args.size,
+					Directory:        tt.args.directory,
 				},
 			)
 			if err != nil {
@@ -140,6 +145,9 @@ func TestUpload(t *testing.T) {
 			if upload1.Extension != tt.wantExt {
 				t.Fatal("bad extension")
 			}
+			if upload1.Directory != tt.wantDir {
+				t.Fatal("incorrect directory settings")
+			}
 			upload2, err := um.NewUpload(
 				tt.args.hash,
 				tt.args.uploadType,
@@ -150,6 +158,7 @@ func TestUpload(t *testing.T) {
 					HoldTimeInMonths: tt.args.holdTime,
 					Encrypted:        tt.args.encrypted,
 					Size:             tt.args.size,
+					Directory:        tt.args.directory,
 				},
 			)
 			if err != nil {
@@ -167,6 +176,9 @@ func TestUpload(t *testing.T) {
 			}
 			if upload2.Extension != tt.wantExt {
 				t.Fatal("bad extension")
+			}
+			if upload2.Directory != tt.wantDir {
+				t.Fatal("incorrect directory setting")
 			}
 			if _, err := um.NewUpload(
 				tt.args.hash,


### PR DESCRIPTION
Adds a field to upload models so that we can differentiate between regular unixfs objects, and directory unixfs objects